### PR TITLE
Fix 5 cookiecutter template issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Sinta-se livre para usar, forkear e modificar a vontade!
 
 1. Instale o [uv](https://docs.astral.sh/uv/getting-started/installation/)
 2. Instale o [Cookiecutter](https://cookiecutter.readthedocs.io/en/latest/installation.html)
-3. Execute `cookiecutter gh:fbidu/cookie-py`
-4. O seu terminal irá te perguntar tudo o que precisar!
+3. Instale o [pre-commit](https://pre-commit.com/#install)
+4. Execute `cookiecutter gh:fbidu/cookie-py`
+5. O seu terminal irá te perguntar tudo o que precisar!
 
 ### Itens Inclusos
 
@@ -70,8 +71,9 @@ Feel free to use, fork and modify at will!
 
 1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
 2. Install [Cookiecutter](https://cookiecutter.readthedocs.io/en/latest/installation.html)
-3. Run `cookiecutter gh:fbidu/cookie-py`
-4. Your terminal will ask you everything it needs!
+3. Install [pre-commit](https://pre-commit.com/#install)
+4. Run `cookiecutter gh:fbidu/cookie-py`
+5. Your terminal will ask you everything it needs!
 
 ### Batteries Included
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,8 +8,5 @@
     "license": "MIT",
     "python_version": "3.12",
     "language": ["EN", "PT-BR", "Both"],
-    "enable_github_copilot": ["yes", "no"],
-    "_copy_without_render": [
-        "*.github/workflows"
-    ]
+    "enable_github_copilot": ["yes", "no"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "GPL-3.0"}
 requires-python = ">=3.12"
 dependencies = []
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "cookiecutter>=2.6.0",
     "pytest>=8.0.0",

--- a/tests/test_cookiecutter_integration.py
+++ b/tests/test_cookiecutter_integration.py
@@ -221,3 +221,31 @@ class TestCookiecutterIntegration:
         # Check that pre-commit ran successfully (even if it made fixes)
         assert "Passed" in result.stdout or "Failed" in result.stdout, \
             f"Pre-commit output unexpected: {result.stdout}"
+
+    def test_workflow_files_rendered(self, temp_dir, template_dir):
+        """Test that workflow files have cookiecutter variables rendered."""
+        # Arrange
+        subprocess.run(
+            ["cookiecutter", str(template_dir), "--no-input", "--output-dir", str(temp_dir)],
+            capture_output=True,
+            cwd=temp_dir,
+        )
+        project_dir = temp_dir / "my-awesome-project"
+
+        # Act - Read workflow files
+        test_yml = (project_dir / ".github/workflows/test.yml").read_text()
+        precommit_yml = (project_dir / ".github/workflows/pre-commit.yml").read_text()
+
+        # Assert - Cookiecutter variables should be rendered
+        assert "{{cookiecutter." not in test_yml, \
+            "Cookiecutter variables not rendered in test.yml"
+        assert "{{cookiecutter." not in precommit_yml, \
+            "Cookiecutter variables not rendered in pre-commit.yml"
+
+        # Assert - Default python_version (3.12) should appear
+        assert "3.12" in test_yml, "Default python_version not rendered in test.yml"
+        assert "3.12" in precommit_yml, "Default python_version not rendered in pre-commit.yml"
+
+        # Assert - GitHub Actions expressions should be preserved
+        assert "${{ matrix.python-version }}" in test_yml, \
+            "GitHub Actions expressions were incorrectly rendered in test.yml"

--- a/tests/test_cookiecutter_integration.py
+++ b/tests/test_cookiecutter_integration.py
@@ -249,3 +249,22 @@ class TestCookiecutterIntegration:
         # Assert - GitHub Actions expressions should be preserved
         assert "${{ matrix.python-version }}" in test_yml, \
             "GitHub Actions expressions were incorrectly rendered in test.yml"
+
+    def test_license_format_is_spdx_string(self, temp_dir, template_dir):
+        """Test that license field uses modern SPDX string format."""
+        # Arrange
+        subprocess.run(
+            ["cookiecutter", str(template_dir), "--no-input", "--output-dir", str(temp_dir)],
+            capture_output=True,
+            cwd=temp_dir,
+        )
+        project_dir = temp_dir / "my-awesome-project"
+
+        # Act - Read pyproject.toml
+        pyproject = (project_dir / "pyproject.toml").read_text()
+
+        # Assert - Should use plain SPDX string format
+        assert 'license = "MIT"' in pyproject, \
+            "License should be a plain SPDX string"
+        assert "{ text =" not in pyproject, \
+            "License should not use deprecated table format"

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ name = "cookie-py"
 version = "2.0.0"
 source = { editable = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "cookiecutter" },
     { name = "pyright" },
@@ -124,15 +124,16 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "cookiecutter", marker = "extra == 'dev'", specifier = ">=2.6.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "cookiecutter", specifier = ">=2.6.0" },
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "ruff", specifier = ">=0.8.0" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "cookiecutter"

--- a/{{cookiecutter.directory_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.directory_name}}/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3

--- a/{{cookiecutter.directory_name}}/.gitignore
+++ b/{{cookiecutter.directory_name}}/.gitignore
@@ -143,4 +143,7 @@ analyzer/reference/*
 analyzer/data/*
 !analyzer/data/.gitkeep
 analyzer/.snakemake
+
+# Node.js (prettier pre-commit hook cache)
+node_modules/
 # End of https://www.gitignore.io/api/python,visualstudiocode

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{cookiecutter.directory_name}}"
 version = "{{cookiecutter.version}}"
 description = "{{cookiecutter.description}}"
 authors = [{ name = "{{cookiecutter.author}}" }]
-license = { text = "{{cookiecutter.license}}" }
+license = "{{cookiecutter.license}}"
 requires-python = ">={{cookiecutter.python_version}}"
 dependencies = []
 

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -7,6 +7,13 @@ license = { text = "{{cookiecutter.license}}" }
 requires-python = ">={{cookiecutter.python_version}}"
 dependencies = []
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["{{cookiecutter.pkg_name}}"]
+
 [dependency-groups]
 dev = [
     "bandit[toml]>=1.8.0",


### PR DESCRIPTION
## Summary

This PR implements 5 critical and minor fixes to the cookiecutter template, all tested and committed atomically:

- **Fix GitHub workflow rendering**: Remove _copy_without_render and use {% raw %} blocks for GitHub Actions expressions
- **Fix node_modules build error**: Add explicit [build-system] config and hatchling backend
- **Fix license deprecation**: Update to modern SPDX string format
- **Fix dev dependencies**: Change [project.optional-dependencies] to [dependency-groups]
- **Document pre-commit prerequisite**: Update README with pre-commit installation steps

## Test Results

All 10 integration tests pass (8 existing + 2 new). Generated projects now build successfully with uv build and have properly rendered templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)