### PR TITLE
chore(renovate): keep GitHub Actions on floating major tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,13 @@
       "matchFileNames": ["template/**"],
       "addLabels": ["template"],
       "semanticCommitScope": "template"
+    },
+    {
+      "description": "Keep GitHub Actions on floating major tags (e.g. @v6); the tag tracks minor/patch at runtime, so only raise PRs for major bumps",
+      "matchFileNames": [".github/workflows/**", "template/.github/workflows/**"],
+      "matchDatasources": ["github-tags"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "enabled": false
     }
   ]
 }

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3

--- a/template/.github/workflows/ci.yml.jinja
+++ b/template/.github/workflows/ci.yml.jinja
@@ -10,14 +10,14 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
       - run: uv python install {{ python_version }}
       - run: uv sync --dev
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/prek
           key: prek-{% raw %}${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}{% endraw %}


### PR DESCRIPTION
## What

Switches GitHub Actions back to **floating major tags** and stops Renovate from raising a PR for every minor/patch action release.

Follow-up to the discussion on #48 / #49: those PRs pinned `actions/checkout@v6 → @v6.0.2` and `actions/cache@v5 → @v5.0.5`. Floating major tags already track minor/patch at runtime, so the exact pins just create churn.

## Changes

- **Revert pins** introduced by #48/#49 back to floating major:
  - `actions/checkout@v6.0.2` → `@v6` (ci + build)
  - `actions/cache@v5.0.5` → `@v5` (ci)
- **New `renovate.json` packageRule**: disable `minor`/`patch`/`pin`/`digest` updates for `github-tags` deps under any workflows directory. Renovate now only opens PRs on **major** bumps (e.g. `@v6 → @v7`).
  - Scoped via `matchFileNames` to both `.github/workflows/**` (native manager) and `template/.github/workflows/**` (custom regex manager).
  - Also covers the `docker/*` actions in `build.yml.jinja`.

## Out of scope (intentionally unchanged)

- pre-commit hook revs in `template/.pre-commit-config.yaml.jinja` — exact pins, keep normal cadence.
- `ghcr.io/astral-sh/uv` Docker base image — docker datasource, not a workflow file.

Validated with `renovate-config-validator` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)