### PR TITLE
chore(renovate): keep setup-uv updated despite floating-major freeze

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,14 @@
       "matchDatasources": ["github-tags"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "enabled": false
+    },
+    {
+      "description": "Exception to the floating-major freeze: setup-uv dropped its floating @v8 tag in v8.0.0 (immutable releases), so it must be exact-pinned. Keep minor/patch PRs flowing so the pin still receives updates between majors.",
+      "matchFileNames": [".github/workflows/**", "template/.github/workflows/**"],
+      "matchDatasources": ["github-tags"],
+      "matchDepNames": ["astral-sh/setup-uv"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a Renovate `packageRule` exception so `astral-sh/setup-uv` keeps receiving minor/patch update PRs, despite the floating-major freeze introduced in #51.

## Why

setup-uv **v8.0.0 removed its floating `@v8`/`@v8.0` tags** ([immutable releases](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0), supply-chain hardening). The action must now be exact-pinned (we're on `@v8.1.0` after #61).

But #51's freeze disables `minor`/`patch`/`pin`/`digest` updates for workflow `github-tags` deps — on the assumption every action floats on its major tag and tracks patches at runtime. That assumption no longer holds for setup-uv: with an exact pin and the freeze in place, Renovate would strand it at `v8.1.0` until the next **major** (`v9`), defeating the point of immutable pinning.

## Change

One `packageRule`, ordered **after** the freeze rule so it wins, scoped to `astral-sh/setup-uv` only, re-enabling `minor`/`patch` updates in workflow files.

Validated with `renovate-config-validator` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)