### PR TITLE
Make generated projects self-maintaining: ship Renovate policy + copier answers

### DIFF
--- a/template/.copier-answers.yml.jinja
+++ b/template/.copier-answers.yml.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+{{ _copier_answers|to_nice_yaml }}

--- a/template/renovate.json
+++ b/template/renovate.json
@@ -1,5 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Keep GitHub Actions on floating major tags (e.g. @v6); the tag tracks minor/patch at runtime, so only raise PRs for major bumps",
+      "matchFileNames": [".github/workflows/**"],
+      "matchDatasources": ["github-tags"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "enabled": false
+    },
+    {
+      "description": "Exception to the floating-major freeze: setup-uv dropped its floating @v8 tag in v8.0.0 (immutable releases), so it must be exact-pinned. Keep minor/patch PRs flowing so the pin still receives updates between majors.",
+      "matchFileNames": [".github/workflows/**"],
+      "matchDatasources": ["github-tags"],
+      "matchDepNames": ["astral-sh/setup-uv"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
## What

Two changes that make projects generated from this template behave like the template repo and stay updatable:

1. **Ship the floating-major Renovate policy** to generated projects (`template/renovate.json`).
2. **Emit `.copier-answers.yml`** from the template so `copier update` works at all.

## Why

### Renovate policy
The floating-major freeze (#51) and the setup-uv exception (#64) live in the **root** `renovate.json`, which only governs *this* repo. Generated projects shipped a bare `config:recommended`, so they'd still get the minor/patch action churn we just eliminated here — and wouldn't know setup-uv needs the exact-pin exception.

Ported both `packageRules` into the shipped `template/renovate.json`, scoped to the child's own `.github/workflows/**` path (children have no `template/` subtree).

> Not symlinked to the root config on purpose: the root config carries template-only `customManagers` and `template/**`-scoped rules that would dangle in a generated project, and Copier renders the `template/` subtree in isolation so an out-of-tree symlink wouldn't resolve.

### Copier answers
Generated projects had no `.copier-answers.yml`, so `copier update` couldn't find a project's source/version and refused to run. Added `template/.copier-answers.yml.jinja` rendering `{{ _copier_answers|to_nice_yaml }}`; every new project now records `_src_path` + `_commit` + answers and is updatable.

## Validation

- `renovate-config-validator template/renovate.json` ✅
- Smoke-tested `copier copy --defaults`: generated project gets a populated `.copier-answers.yml` and a `renovate.json` carrying the policy ✅

## Follow-up (not in this PR)

- **Tag the template** (e.g. `v0.1.0`) — `copier update` moves projects between git tags, and there are none yet.
- Projects generated *before* this lands won't have an answers file; they need a one-time bootstrap `.copier-answers.yml` before they can `copier update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)