### PR TITLE
feat(template): weekly copier-update CI for generated projects

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -113,6 +113,7 @@ _exclude:
   - "*.pyc"
   - "{% if ci_provider != 'github' %}.github/workflows/ci.yml{% endif %}"
   - "{% if ci_provider != 'github' %}.github/workflows/build.yml{% endif %}"
+  - "{% if ci_provider != 'github' %}.github/workflows/copier-update.yml{% endif %}"
   - "{% if ci_provider != 'gitlab' %}.gitlab-ci.yml{% endif %}"
   - "{% if dependency_updates != 'renovate' %}renovate.json{% endif %}"
   - "{% if dependency_updates != 'renovate' or ci_provider != 'github' %}.github/workflows/renovate.yml{% endif %}"

--- a/template/.github/workflows/copier-update.yml.jinja
+++ b/template/.github/workflows/copier-update.yml.jinja
@@ -1,0 +1,65 @@
+# Weekly check for upstream template updates via Copier.
+#
+# When the template recorded in .copier-answers.yml has newer changes, this
+# opens (or refreshes) a `chore/copier-update` pull request. It NEVER runs
+# the template's post-generation task (git init / initial commit / repo
+# creation) — that must only happen at project creation, so the job runs
+# `copier update` without --trust (Copier then skips tasks) and also sets
+# SKIP_POST_GENERATE as a second guard.
+#
+# Auth: uses the built-in GITHUB_TOKEN through the `gh` CLI — nothing to set
+# up. Two things to know:
+#   * Enable Settings > Actions > General > "Allow GitHub Actions to create
+#     and approve pull requests".
+#   * PRs opened with GITHUB_TOKEN don't trigger other workflows, so CI
+#     won't start automatically on the update PR — push a commit or close/
+#     reopen it to run CI. (Swap GH_TOKEN below for a PAT if you'd rather it
+#     run CI automatically.)
+name: Copier Update
+
+on:
+  schedule:
+    - cron: "0 6 * * 4"  # Thursdays 06:00 UTC (offset from Renovate's Monday run)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  copier-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v8.1.0
+      - name: Run copier update
+        env:
+          SKIP_POST_GENERATE: "1"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # No --trust → Copier skips template tasks/migrations (safe for an
+          # unattended run); --defaults answers any newly added questions.
+          uvx copier update --defaults
+      - name: Open or refresh pull request
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No template changes — nothing to do."
+            exit 0
+          fi
+          BRANCH="chore/copier-update"
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "chore: update from template via copier"
+          git push --force origin "$BRANCH"
+          if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -qx OPEN; then
+            echo "Existing PR refreshed with the latest template changes."
+          else
+            gh pr create --head "$BRANCH" \
+              --title "chore: copier template update" \
+              --body "Automated \`copier update\` run. Review the changes and resolve any \`*.rej\` conflict files before merging."
+          fi

--- a/template/.gitlab-ci.yml.jinja
+++ b/template/.gitlab-ci.yml.jinja
@@ -1,9 +1,7 @@
 stages:
   - test
   - build
-{% if dependency_updates == "renovate" %}
   - maintenance
-{% endif %}
 
 variables:
   IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
@@ -81,3 +79,48 @@ renovate:
   script:
     - renovate $CI_PROJECT_PATH
 {% endif %}
+
+# --- Template sync (copier) ---
+# Weekly `copier update` that opens an MR when the upstream template (the one
+# recorded in .copier-answers.yml) has newer changes. Runs only on scheduled
+# pipelines. It never runs the template's post-generation task — `copier
+# update` runs without --trust (so Copier skips tasks) and SKIP_POST_GENERATE
+# is set as a second guard.
+# To enable it:
+#   1. Settings > CI/CD > Variables: add a masked, protected
+#      COPIER_UPDATE_TOKEN (Project/Group Access Token with `api` +
+#      `write_repository` scopes, Developer role). The built-in CI_JOB_TOKEN
+#      can neither push branches nor open MRs. You may reuse RENOVATE_TOKEN
+#      if its scopes cover write_repository.
+#   2. Build > Pipeline schedules: add a weekly schedule on your default
+#      branch (reuse the Renovate schedule if you have one).
+# The MR is created via GitLab push options — no extra CLI needed.
+copier-update:
+  stage: maintenance
+  image: python:{{ python_version }}-slim
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+  variables:
+    GIT_STRATEGY: clone
+    GIT_DEPTH: "0"
+  before_script:
+    - apt-get update && apt-get install -y --no-install-recommends git ca-certificates
+    - pip install uv
+  script:
+    - git config user.email "copier-update@$CI_SERVER_HOST"
+    - git config user.name "copier-update"
+    - SKIP_POST_GENERATE=1 uvx copier update --defaults
+    - |
+      if [ -z "$(git status --porcelain)" ]; then
+        echo "No template changes — nothing to do."
+        exit 0
+      fi
+      git checkout -B chore/copier-update
+      git add -A
+      git commit -m "chore: update from template via copier"
+      git remote set-url origin "https://oauth2:${COPIER_UPDATE_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+      git push -f origin chore/copier-update \
+        -o merge_request.create \
+        -o merge_request.target="$CI_DEFAULT_BRANCH" \
+        -o merge_request.title="chore: copier template update" \
+        -o merge_request.description="Automated copier update. Resolve any *.rej conflict files before merging."


### PR DESCRIPTION
## What

Generated projects can now keep themselves in sync with the template. A scheduled **weekly** job runs `copier update` and opens a PR/MR whenever the upstream template (recorded in `.copier-answers.yml`) has newer changes. Always-on whenever a CI provider is selected — no new copier question.

- **GitHub** — new `template/.github/workflows/copier-update.yml.jinja` (gated on `ci_provider == github`). Authenticates via the built-in `GITHUB_TOKEN` through the `gh` CLI, so there's **nothing to configure**. Weekly cron (Thu 06:00 UTC, offset from Renovate's Monday) + `workflow_dispatch`.
- **GitLab** — a `copier-update` job added to `template/.gitlab-ci.yml.jinja`, runs only on scheduled pipelines and opens the MR via **git push options** (no extra CLI). Needs a documented `COPIER_UPDATE_TOKEN` because GitLab's built-in `CI_JOB_TOKEN` can neither push branches nor open MRs — mirrors exactly what the existing Renovate job already documents. The `maintenance` stage is now always declared since this job is unconditional.

## Safety: never re-run the post-generation task

`tasks/post_generate.py` is destructive if re-run on an existing project (`git init`, a fresh "Initial commit", `git branch -M main`, even `glab repo create`). Both jobs guard against it two ways:
- run `copier update` **without `--trust`** → Copier skips template tasks/migrations;
- set **`SKIP_POST_GENERATE=1`** → the script early-returns even if ever run with trust.

`--defaults` keeps the run non-interactive (reuses recorded answers, defaults any newly-added questions). On conflict, Copier leaves `*.rej` files — both jobs commit them so a human resolves in the PR/MR.

## Validation

- Smoke-tested `copier copy --vcs-ref HEAD` for **both** providers: the right files render, the other provider's files are correctly excluded, and both rendered YAMLs parse.
- Confirmed the `${{ github.token }}` GitHub expression survives Jinja via `{% raw %}` wrapping.

## Note for consumers

- An update PR opened with `GITHUB_TOKEN` won't auto-trigger CI (GitHub limitation) — documented inline, with a one-line PAT swap if desired.
- Only works for projects generated from `v0.1.0`+ (they carry `.copier-answers.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)