### PR TITLE
fix(template): copier-update needs --trust to apply updates

### DIFF
--- a/template/.github/workflows/copier-update.yml.jinja
+++ b/template/.github/workflows/copier-update.yml.jinja
@@ -1,11 +1,12 @@
 # Weekly check for upstream template updates via Copier.
 #
 # When the template recorded in .copier-answers.yml has newer changes, this
-# opens (or refreshes) a `chore/copier-update` pull request. It NEVER runs
-# the template's post-generation task (git init / initial commit / repo
-# creation) — that must only happen at project creation, so the job runs
-# `copier update` without --trust (Copier then skips tasks) and also sets
-# SKIP_POST_GENERATE as a second guard.
+# opens (or refreshes) a `chore/copier-update` pull request. It must NEVER
+# run the template's post-generation task (git init / initial commit / repo
+# creation) — that only belongs at project creation. Copier requires
+# --trust to apply an update when the template declares tasks (without it
+# the whole update aborts), so the job passes --trust but sets
+# SKIP_POST_GENERATE, which makes post_generate.py a no-op.
 #
 # Auth: uses the built-in GITHUB_TOKEN through the `gh` CLI — nothing to set
 # up. Two things to know:
@@ -40,9 +41,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # No --trust → Copier skips template tasks/migrations (safe for an
-          # unattended run); --defaults answers any newly added questions.
-          uvx copier update --defaults
+          # --trust lets Copier apply updates from a template that declares
+          # tasks; SKIP_POST_GENERATE (set above) neuters the post-generation
+          # task so nothing destructive runs. --defaults answers any newly
+          # added questions non-interactively.
+          uvx copier update --defaults --trust
       - name: Open or refresh pull request
         env:
           GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}

--- a/template/.gitlab-ci.yml.jinja
+++ b/template/.gitlab-ci.yml.jinja
@@ -83,9 +83,9 @@ renovate:
 # --- Template sync (copier) ---
 # Weekly `copier update` that opens an MR when the upstream template (the one
 # recorded in .copier-answers.yml) has newer changes. Runs only on scheduled
-# pipelines. It never runs the template's post-generation task — `copier
-# update` runs without --trust (so Copier skips tasks) and SKIP_POST_GENERATE
-# is set as a second guard.
+# pipelines. Copier requires --trust to apply an update when the template
+# declares tasks; SKIP_POST_GENERATE makes the post-generation task a no-op,
+# so nothing destructive (git init / initial commit / repo creation) runs.
 # To enable it:
 #   1. Settings > CI/CD > Variables: add a masked, protected
 #      COPIER_UPDATE_TOKEN (Project/Group Access Token with `api` +
@@ -109,7 +109,7 @@ copier-update:
   script:
     - git config user.email "copier-update@$CI_SERVER_HOST"
     - git config user.name "copier-update"
-    - SKIP_POST_GENERATE=1 uvx copier update --defaults
+    - SKIP_POST_GENERATE=1 uvx copier update --defaults --trust
     - |
       if [ -z "$(git status --porcelain)" ]; then
         echo "No template changes — nothing to do."


### PR DESCRIPTION
## The bug

Tested the copier-update feature end-to-end and found it never applies updates. When a template declares `_tasks` (this one does — `post_generate.py`), `copier update` **without `--trust` aborts the whole update** (exit 4, "Template uses potentially unsafe feature: tasks") instead of applying files and skipping tasks. The job shipped in #68 / `v0.2.0` would no-op on every run.

| Mode | Result |
|------|--------|
| `copier update --defaults` (no `--trust`) | exit 4, **nothing updated** |
| `copier update --defaults --trust` + `SKIP_POST_GENERATE=1` | exit 0, updates cleanly, task neutered |

## The fix

Pass `--trust` in both jobs and rely on `SKIP_POST_GENERATE=1` (already set) to make `post_generate.py` early-return. That env guard — not the absence of `--trust` — is what keeps the update non-destructive. Comments updated to match.

## Verification

End-to-end: generated a project from `v0.1.0`, ran the corrected command, confirmed it updates to the new version and gains the `copier-update.yml` workflow with **no** git-init / initial-commit / repo-creation side effects. Rendered GitHub workflow re-checked with actionlint (via prek) — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)