### PR TITLE
chore(template): guard copier-update jobs against overlapping runs

### DIFF
--- a/template/.github/workflows/copier-update.yml.jinja
+++ b/template/.github/workflows/copier-update.yml.jinja
@@ -27,6 +27,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# A scheduled run and a manual one shouldn't fight over the update branch.
+concurrency:
+  group: copier-update
+  cancel-in-progress: true
+
 jobs:
   copier-update:
     runs-on: ubuntu-latest

--- a/template/.gitlab-ci.yml.jinja
+++ b/template/.gitlab-ci.yml.jinja
@@ -98,6 +98,7 @@ renovate:
 copier-update:
   stage: maintenance
   image: python:{{ python_version }}-slim
+  interruptible: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
   variables:


### PR DESCRIPTION
Adds `concurrency: cancel-in-progress` to the GitHub copier-update workflow and `interruptible: true` to the GitLab job, so a manual run and a scheduled run don't race on the `chore/copier-update` branch.

Doubles as the `v0.2.2` bump that the demo repos will pull via `copier update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)