### PR TITLE
fix(template): copier-update GitHub job needs a workflow-scoped PAT

### DIFF
--- a/template/.github/workflows/copier-update.yml.jinja
+++ b/template/.github/workflows/copier-update.yml.jinja
@@ -8,14 +8,12 @@
 # the whole update aborts), so the job passes --trust but sets
 # SKIP_POST_GENERATE, which makes post_generate.py a no-op.
 #
-# Auth: uses the built-in GITHUB_TOKEN through the `gh` CLI — nothing to set
-# up. Two things to know:
-#   * Enable Settings > Actions > General > "Allow GitHub Actions to create
-#     and approve pull requests".
-#   * PRs opened with GITHUB_TOKEN don't trigger other workflows, so CI
-#     won't start automatically on the update PR — push a commit or close/
-#     reopen it to run CI. (Swap GH_TOKEN below for a PAT if you'd rather it
-#     run CI automatically.)
+# Auth: needs a token with `repo` + `workflow` scopes saved as the
+# COPIER_UPDATE_TOKEN repository secret (classic PAT, or a GitHub App token
+# via actions/create-github-app-token). The `workflow` scope is required
+# because template updates routinely touch files under .github/workflows/,
+# and the built-in GITHUB_TOKEN is forbidden from pushing those. Using a PAT
+# also means CI runs normally on the update PR.
 name: Copier Update
 
 on:
@@ -39,6 +37,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Persist the PAT so the later `git push` can update workflow files.
+          token: {% raw %}${{ secrets.COPIER_UPDATE_TOKEN }}{% endraw %}
       - uses: astral-sh/setup-uv@v8.1.0
       - name: Run copier update
         env:
@@ -53,7 +53,7 @@ jobs:
           uvx copier update --defaults --trust
       - name: Open or refresh pull request
         env:
-          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.COPIER_UPDATE_TOKEN }}{% endraw %}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
             echo "No template changes — nothing to do."


### PR DESCRIPTION
## Found via the live demo

Ran the GitHub demo end-to-end on a real repo. `copier update` worked perfectly — it produced the right diff (answers `_commit` bump + the `concurrency` change) and committed it — but the **push was rejected**:

> `! [remote rejected] ... refusing to allow a GitHub App to create or update workflow .github/workflows/copier-update.yml without `workflows` permission`

The built-in `GITHUB_TOKEN` is **forbidden from pushing files under `.github/workflows/`**, and template updates routinely touch workflows. So the zero-config approach can't work for this use case.

## Fix

Use a `COPIER_UPDATE_TOKEN` secret (PAT with `repo` + `workflow` scopes) for both `actions/checkout` (so the push carries workflow permission) and `gh`. This mirrors the template's own `renovate.yml`, which needs the exact same scope for the same reason — and as a bonus the update PR now triggers CI normally (another GITHUB_TOKEN limitation gone).

GitLab is unaffected — it has no equivalent restriction on pushing `.gitlab-ci.yml`.

Verified: rendered workflow passes actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)