### PR TITLE
docs(template): document copier update in generated README

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -62,6 +62,23 @@ To activate it:
 Point a Renovate runner — the [hosted app](https://github.com/apps/renovate) or a scheduled CI job — at this repo and it will pick up `renovate.json`.
 {% endif %}
 {% endif %}
+{% if ci_provider == "github" or ci_provider == "gitlab" %}
+### Template updates
+
+This project was generated from [cookie-py](https://github.com/fbidu/cookie-py) with [Copier](https://copier.readthedocs.io/), which records the template version in `.copier-answers.yml`. Pull later template changes anytime with:
+
+```bash
+copier update --trust
+```
+
+A scheduled job also checks weekly and opens a {% if ci_provider == "github" %}PR{% else %}merge request{% endif %} when the template has newer changes. To enable it:
+{% if ci_provider == "github" %}
+- Add a `COPIER_UPDATE_TOKEN` repository secret — a PAT with `repo` + `workflow` scopes. The `workflow` scope is required because updates can touch files under `.github/workflows/`, which the built-in `GITHUB_TOKEN` cannot push.
+{% elif ci_provider == "gitlab" %}
+1. Add a masked `COPIER_UPDATE_TOKEN` CI/CD variable — a Project or Group Access Token with `api` + `write_repository` scopes.
+2. Create a **pipeline schedule** on your default branch (the `copier-update` job runs only on scheduled pipelines).
+{% endif %}
+{% endif %}
 
 {% endif %}
 {% if language == "Both" or language == "PT-BR" %}
@@ -116,6 +133,23 @@ Para ativar:
 2. Crie um **agendamento de pipeline** (ex.: semanal) na sua branch padrão. O job `renovate` roda apenas em pipelines agendados.
 {% else %}
 Aponte um runner do Renovate — o [app hospedado](https://github.com/apps/renovate) ou um job de CI agendado — para este repositório e ele usará o `renovate.json`.
+{% endif %}
+{% endif %}
+{% if ci_provider == "github" or ci_provider == "gitlab" %}
+### Atualização do template
+
+Este projeto foi gerado a partir do [cookie-py](https://github.com/fbidu/cookie-py) com o [Copier](https://copier.readthedocs.io/), que registra a versão do template em `.copier-answers.yml`. Traga mudanças posteriores do template a qualquer momento com:
+
+```bash
+copier update --trust
+```
+
+Um job agendado também verifica semanalmente e abre {% if ci_provider == "github" %}um PR{% else %}um merge request{% endif %} quando o template tem novidades. Para ativar:
+{% if ci_provider == "github" %}
+- Adicione um secret `COPIER_UPDATE_TOKEN` — um PAT com escopos `repo` + `workflow`. O escopo `workflow` é necessário porque atualizações podem mexer em arquivos sob `.github/workflows/`, que o `GITHUB_TOKEN` embutido não consegue enviar.
+{% elif ci_provider == "gitlab" %}
+1. Adicione uma variável CI/CD mascarada `COPIER_UPDATE_TOKEN` — um Project/Group Access Token com escopos `api` + `write_repository`.
+2. Crie um **agendamento de pipeline** na sua branch padrão (o job `copier-update` roda apenas em pipelines agendados).
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Adds a **Template updates** section (EN + PT-BR, gated on `ci_provider`) to the generated project's README, covering `copier update --trust` and how to enable the weekly update job with the right token per provider.

Also serves as the `v0.2.4` bump for the end-to-end demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)