### PR TITLE
fix(template): copier-update jobs handle merge conflicts gracefully

### DIFF
--- a/template/.github/workflows/copier-update.yml.jinja
+++ b/template/.github/workflows/copier-update.yml.jinja
@@ -60,14 +60,23 @@ jobs:
             exit 0
           fi
           BRANCH="chore/copier-update"
-          git checkout -B "$BRANCH"
+          # copier's 3-way merge can leave conflict markers and an unmerged
+          # index. Record whether that happened, then `git add -A` (which also
+          # resolves the index) so the conflicts ride along in the PR rather
+          # than crashing the job — a human resolves them there.
+          CONFLICTS="$(git ls-files --unmerged)"
           git add -A
+          git checkout -B "$BRANCH"
           git commit -m "chore: update from template via copier"
           git push --force origin "$BRANCH"
+          TITLE="chore: copier template update"
+          BODY="Automated \`copier update\` run. Review the changes before merging."
+          if [ -n "$CONFLICTS" ]; then
+            TITLE="$TITLE (conflicts to resolve)"
+            BODY="Automated \`copier update\` run that hit merge conflicts. Resolve the conflict markers (\`<<<<<<<\` / \`>>>>>>>\`) before merging."
+          fi
           if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -qx OPEN; then
             echo "Existing PR refreshed with the latest template changes."
           else
-            gh pr create --head "$BRANCH" \
-              --title "chore: copier template update" \
-              --body "Automated \`copier update\` run. Review the changes and resolve any \`*.rej\` conflict files before merging."
+            gh pr create --head "$BRANCH" --title "$TITLE" --body "$BODY"
           fi

--- a/template/.gitlab-ci.yml.jinja
+++ b/template/.gitlab-ci.yml.jinja
@@ -116,12 +116,15 @@ copier-update:
         echo "No template changes — nothing to do."
         exit 0
       fi
-      git checkout -B chore/copier-update
+      # Stage everything first — this resolves any unmerged index left by
+      # copier's 3-way merge so the branch can be created and the conflicts
+      # travel into the MR for a human to resolve, instead of failing the job.
       git add -A
+      git checkout -B chore/copier-update
       git commit -m "chore: update from template via copier"
       git remote set-url origin "https://oauth2:${COPIER_UPDATE_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
       git push -f origin chore/copier-update \
         -o merge_request.create \
         -o merge_request.target="$CI_DEFAULT_BRANCH" \
         -o merge_request.title="chore: copier template update" \
-        -o merge_request.description="Automated copier update. Resolve any *.rej conflict files before merging."
+        -o merge_request.description="Automated copier update. Resolve any conflict markers (<<<<<<< / >>>>>>>) before merging."


### PR DESCRIPTION
## Found via the live demo (bug #3)

With the PAT fix in place, the GitHub job got past the push — but then crashed:

> `error: you need to resolve your current index first` / `README.md: needs merge`

`copier update` does a **git 3-way merge** and leaves conflict markers + an unmerged index whenever the project's committed files diverge from copier's recorded render. That divergence is common: prek reformats files at generation time (e.g. collapses Jinja-induced blank-line runs), so the committed README ≠ the raw render, and the next update can't auto-merge. The job then died on `git checkout -B`.

## Fix

`git add -A` first (which resolves the unmerged index), *then* create the branch and commit — so the conflicts ride along into the PR/MR for a human to resolve instead of failing the job. The GitHub PR title/body is flagged when conflicts are present.

Applied to both the GitHub workflow and the GitLab job. Verified: rendered GitHub workflow passes actionlint, both YAMLs parse.

## Related follow-up (not here)

The *underlying* reason updates conflict at all is that the template's rendered output isn't prek-clean (stray blank-line runs from stacked Jinja conditionals). Making the render already-formatted would give conflict-free updates for unmodified projects — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)