### PR TITLE
fix(template): GitLab CI — pyright libatomic + decouple maintenance jobs

### DIFF
--- a/template/.gitlab-ci.yml.jinja
+++ b/template/.gitlab-ci.yml.jinja
@@ -23,6 +23,9 @@ type-check:
   stage: test
   image: python:{{ python_version }}-slim
   before_script:
+    # pyright ships its own Node, which needs libatomic at runtime — absent
+    # from the slim image ("libatomic.so.1: cannot open shared object file").
+    - apt-get update && apt-get install -y --no-install-recommends libatomic1
     - pip install uv
     - uv sync --dev
   script:
@@ -69,6 +72,8 @@ build:
 renovate:
   stage: maintenance
   image: renovate/renovate:latest
+  # Don't gate maintenance on the project's own test stage.
+  needs: []
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
   variables:
@@ -99,6 +104,9 @@ copier-update:
   stage: maintenance
   image: python:{{ python_version }}-slim
   interruptible: true
+  # Run independently of the test stage — a template sync shouldn't be blocked
+  # by the project's own tests failing.
+  needs: []
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
   variables:


### PR DESCRIPTION
Two issues found running the generated GitLab CI on a real runner during the end-to-end demo:

1. **`type-check` fails on the slim image** — pyright's bundled Node can't start: `libatomic.so.1: cannot open shared object file`. `python:*-slim` lacks it. Install `libatomic1` in that job's `before_script`.
2. **Maintenance jobs gated by the test stage** — `copier-update` and `renovate` were *skipped* whenever `type-check`/`test` failed, so a failing project test suite would silently block template and dependency updates. Add `needs: []` so they run independently.

Verified: rendered `.gitlab-ci.yml` parses, `type-check` installs libatomic1, both maintenance jobs have `needs: []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)